### PR TITLE
mount: use blkid to determine fstype

### DIFF
--- a/include/volume_id.h
+++ b/include/volume_id.h
@@ -18,6 +18,7 @@
  *	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 
+char *get_fstype_from_devname(const char *device);
 char *get_devname_from_label(const char *spec);
 char *get_devname_from_uuid(const char *spec);
 void display_uuid_cache(int scan_devices);

--- a/util-linux/volume_id/get_devname.c
+++ b/util-linux/volume_id/get_devname.c
@@ -266,6 +266,19 @@ int add_to_uuid_cache(const char *device)
 	return 0;
 }
 
+char *get_fstype_from_devname(const char *device)
+{
+#if ENABLE_FEATURE_BLKID_TYPE
+	struct uuidCache_s *uc;
+
+	add_to_uuid_cache(device);
+	uc = uuidcache_init(0);
+
+	return uc->type;
+#else
+	return NULL;
+#endif
+}
 
 /* Used by mount and findfs */
 


### PR DESCRIPTION
* Add a function to volume_id that returns an fstype for a
  given device.

* During mount, if the fstype is auto, or blkid disagrees
  with the given fstype, trust blkid's determination of the
  filesystem type and run with it.

Change-Id: I357cbb5d255a30a27152a06de5328b2ef14553f9